### PR TITLE
Set up initial cloud messaging config for push notification

### DIFF
--- a/noodle/android/app/src/main/AndroidManifest.xml
+++ b/noodle/android/app/src/main/AndroidManifest.xml
@@ -31,6 +31,10 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <intent-filter>
+                <action android:name="FLUTTER_NOTIFICATION_CLICK" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/noodle/lib/app.dart
+++ b/noodle/lib/app.dart
@@ -9,6 +9,7 @@ import 'package:noodle/src/core/repositories/authentication_repository.dart';
 import 'package:noodle/src/core/repositories/user_repository.dart';
 import 'package:noodle/src/resources/pages/landing/auth_landing.dart';
 import 'package:flutter/material.dart';
+//import 'package:noodle/src/core/models/push_notification.dart';
 
 // import 'package:noodle/src/resources/theme/theme.dart';
 // ignore: import_of_legacy_library_into_null_safe

--- a/noodle/lib/src/core/models/push_notification.dart
+++ b/noodle/lib/src/core/models/push_notification.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class PushNotificationDemo extends StatelessWidget {
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: PushNotification(),
+    );
+  }
+}
+class PushNotification extends StatefulWidget {
+  @override
+  _PushNotificationState createState() => _PushNotificationState();
+}
+
+class _PushNotificationState extends State<PushNotification> {
+  final Firestore _fdb = Firestore.instance; // database to save device token
+  final FirebaseMessaging _fcm = FirebaseMessaging();
+
+  // SENDING NOTIFICATION
+  // Type 1: Single device notification
+  // TODO
+//  _saveToken() async {
+//    // Once user has signed in, obtain device token and save it to database
+//    // String uid = $userid;
+//    // FirebaseUser user = await _auth.currentUser();  // uncomment this
+//    String fcmToken = await _fcm.getToken();
+//    if (fcmToken != null) {
+//      var tokens = _fdb
+//          .collection('users')
+//          .document(uid)
+//          .collection('tokens')
+//          .document(fcmToken);
+//
+//      await tokens.setData({
+//        'token': fcmToken
+//      });
+//    }
+//  }
+  // Type 2: User segment notification
+  // Go to Firebase Console to create user segment and send notification
+  // TODO Confirm if this type of notification is necessary
+
+  // Type 3: Topic subscription notification
+  // Send notification to user based on subscribed topics
+  // TODO Confirm if this type of notification is necessary
+
+  // RECEIVING NOTIFICATION
+  // Callback functions to handle the incoming notification
+  @override
+  void initState() {
+    _fcm.configure(
+      // onMessage is executed when the app is open and running in foreground
+      // Display a dialog pop up that contains message of the notification
+      onMessage: (Map<String, dynamic> message) async {
+        print("onMessage: $message");
+        showDialog(
+          context: context,
+          builder: (context) =>
+              AlertDialog(
+                content: ListTile(
+                  title: Text(message['notification']['title']),
+                  subtitle: Text(message['notification']['body']),
+                ),
+                actions: <Widget>[
+                  ElevatedButton(
+                    child: Text('Ok'),
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                ],
+              ),
+        );
+      },
+      // onLaunch is executed when the app is closed
+      // By default, display notification on the device's slide down
+      onLaunch: (Map<String, dynamic> message) async {
+        print("onLaunch: $message");
+      },
+      // onResume is executed when the app is running in the background
+      // By default, display notification on the device's slide down
+      onResume: (Map<String, dynamic> message) async {
+        print("onResume: $message");
+      },
+      // TODO Handle click event and navigate to certain screen
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+        ),
+      ),
+    );
+  }
+}

--- a/noodle/pubspec.lock
+++ b/noodle/pubspec.lock
@@ -99,6 +99,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.0"
+  cloud_firestore:
+    dependency: "direct main"
+    description:
+      name: cloud_firestore
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.12.11"
   code_builder:
     dependency: transitive
     description:
@@ -246,6 +253,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  firebase_messaging:
+    dependency: "direct main"
+    description:
+      name: firebase_messaging
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.1.8"
   fixnum:
     dependency: transitive
     description:
@@ -626,7 +640,7 @@ packages:
       name: platform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "2.2.1"
   plugin_platform_interface:
     dependency: transitive
     description:

--- a/noodle/pubspec.yaml
+++ b/noodle/pubspec.yaml
@@ -63,6 +63,9 @@ dependencies:
   firebase_auth: ^0.14.0+5
   flutter_facebook_login: ^3.0.0
   google_sign_in: ^4.5.3
+  # dependencies for cloud messaging service
+  cloud_firestore: ^0.12.5
+  firebase_messaging: ^5.0.2
 
 dev_dependencies:
   #  flutter_launcher_icons: "^0.9.0"


### PR DESCRIPTION
**User Story:** Send push notification #5 
**Walk through:** Single device notification 
1. Create and send notification message from Firebase console 
![image](https://user-images.githubusercontent.com/57213243/115989973-23b69d00-a5eb-11eb-9ce6-7b41e84bffaf.png) 
![image](https://user-images.githubusercontent.com/57213243/115989988-2dd89b80-a5eb-11eb-905e-13616d8904b0.png)

2. User receives notification message
a. When the app is running in the foreground 
![image](https://user-images.githubusercontent.com/57213243/115990024-519be180-a5eb-11eb-8e9b-82b95d88c4c4.png)
b. When the app is closed OR running in the background 
![image](https://user-images.githubusercontent.com/57213243/115990041-637d8480-a5eb-11eb-80ff-fda54fedddeb.png)

**Change(s):**
- Configure push notification with Firebase Cloud Messaging service

Related package(s): https://firebase.flutter.dev/docs/messaging/overview/

**Future changelog/improvement:**
- Split widgets
- Configure the app with Firebase admin account instead of developer's personal account
- Identify which type of notification we want to send (i.e: to single device, by user segment or by topic subscription)
- Identify topic and navigation route of each notification topic (for example: notification about new message will navigate user to their inbox) 
